### PR TITLE
feat: push notifications backend (device tokens + FCM)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,9 +2,16 @@
 .idea/
 
 # Python
+venv/
 .venv/
 .ven/
 __pycache__/
 *.py[cod]
 *.pyo
 .Python
+
+# Firebase service account JSONs — credenciales sensibles, viven en K8s
+# Secret. Cualquier archivo que matchee este patrón está prohibido.
+*firebase-adminsdk*.json
+firebase-service-account*.json
+google-services.json

--- a/services/service-core/domain/models/device_token.py
+++ b/services/service-core/domain/models/device_token.py
@@ -1,0 +1,43 @@
+"""SQLModel para los tokens de notificación push de cada dispositivo del usuario.
+
+Cada usuario puede tener N tokens activos (un dispositivo Android, otro iOS,
+una pestaña de navegador, etc.). El cliente registra el token al iniciar
+sesión y lo refresca cuando FCM/APNs lo rota. Lo borramos al hacer logout
+explícito desde ese mismo dispositivo.
+
+Diseño:
+
+- `(user_id, token)` es UNIQUE: la combinación es la identidad del registro,
+  no usamos el `id` para upserts. Permite que el mismo dispositivo pertenezca
+  a varios usuarios si se loguean en serie.
+- `last_seen_at` se actualiza en cada upsert para poder podar tokens
+  inactivos por una tarea de mantenimiento (>30d).
+- `platform` es un enum simple: por ahora solo `android`, pero `ios` y `web`
+  ya están reservados para no migrar el schema cuando se sumen.
+"""
+from sqlmodel import Field, SQLModel
+from typing import Optional
+import datetime
+import uuid
+
+
+class DeviceToken(SQLModel, table=True):
+    __tablename__ = "device_tokens"
+
+    id: uuid.UUID = Field(default_factory=uuid.uuid4, primary_key=True)
+    user_id: uuid.UUID = Field(index=True)
+    token: str = Field(max_length=512)
+    platform: str = Field(max_length=16)  # 'android' | 'ios' | 'web'
+    app_version: Optional[str] = Field(default=None, max_length=32)
+    # `TIMESTAMP WITHOUT TIME ZONE` en la columna → guardamos naive UTC para
+    # ser consistentes con el resto de tablas de service-core (que usan el
+    # mismo tipo). El cliente que consuma esto puede asumir UTC.
+    last_seen_at: datetime.datetime = Field(
+        default_factory=lambda: datetime.datetime.utcnow()
+    )
+    created_at: datetime.datetime = Field(
+        default_factory=lambda: datetime.datetime.utcnow()
+    )
+
+    def __str__(self) -> str:
+        return f"DeviceToken<{self.platform}:{self.token[:8]}…>"

--- a/services/service-core/infrastructure/database.py
+++ b/services/service-core/infrastructure/database.py
@@ -26,6 +26,10 @@ async def init_db():
         import domain.models.inventory_calendar
         import domain.models.task_order
         import domain.models.reservation
+        # Push notifications (TRAVEL-173): tabla device_tokens. Se auto-crea
+        # acá; en prod la migración manual `migrations/create_device_tokens.sql`
+        # también la crea.
+        import domain.models.device_token  # noqa: F401
         await conn.run_sync(SQLModel.metadata.create_all)
 
 async def get_session() -> AsyncGenerator[AsyncSession, None]:

--- a/services/service-core/infrastructure/notifications/fcm_sender.py
+++ b/services/service-core/infrastructure/notifications/fcm_sender.py
@@ -1,0 +1,149 @@
+"""FCM (Firebase Cloud Messaging) sender vía Firebase Admin SDK.
+
+Diseño:
+
+- **Init perezosa**: la primera llamada a `send_to_tokens` intenta inicializar
+  Firebase Admin con el JSON del service account. Si falta la env var o el
+  archivo no existe, marca la inicialización como fallida y todas las
+  llamadas siguientes son no-op. Esto permite correr service-core en local
+  o tests sin Firebase configurado — el reservation flow no falla por falta
+  de push.
+- **No-op tolerante**: si Firebase no está listo o un envío individual falla,
+  devolvemos el count de éxitos sin levantar. El push es nice-to-have; la
+  reserva NO debe abortarse porque un token esté caducado.
+- **Threadsafe**: la flag `_initialized` se setea una sola vez; el SDK
+  internamente sincroniza la app default global.
+
+Variables de entorno (probadas en orden — se usa la primera que exista):
+
+    FIREBASE_SERVICE_ACCOUNT_JSON — contenido del JSON inline. Recomendado en
+        Kubernetes / contenedores: el secret se monta como env var sin tocar
+        el filesystem.
+
+    FIREBASE_SERVICE_ACCOUNT_PATH — path absoluto al JSON descargado de
+        Firebase Console (Project Settings → Service accounts → Generate new
+        private key). Útil en local dev.
+
+Si ninguna está, el sender queda inactivo y todas las llamadas devuelven 0
+sin levantar — la reserva nunca falla por falta de push.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import threading
+from typing import Iterable, Optional
+
+try:
+    import firebase_admin
+    from firebase_admin import credentials, messaging
+    _HAS_FIREBASE = True
+except ImportError:
+    _HAS_FIREBASE = False
+    firebase_admin = None  # type: ignore[assignment]
+    credentials = None  # type: ignore[assignment]
+    messaging = None  # type: ignore[assignment]
+
+
+_init_lock = threading.Lock()
+_init_attempted = False
+_initialized = False
+
+
+def _maybe_initialize() -> bool:
+    global _init_attempted, _initialized
+    with _init_lock:
+        if _init_attempted:
+            return _initialized
+        _init_attempted = True
+
+        if not _HAS_FIREBASE:
+            logging.warning(
+                "[FCM] firebase-admin no instalado; push notifications inactivas"
+            )
+            return False
+
+        cred = _build_credential()
+        if cred is None:
+            return False
+
+        try:
+            firebase_admin.initialize_app(cred)
+            _initialized = True
+            logging.info("[FCM] Firebase Admin SDK inicializado")
+            return True
+        except Exception as e:  # pragma: no cover — depende del entorno real
+            logging.error(f"[FCM] error inicializando Firebase Admin: {e}")
+            return False
+
+
+def _build_credential():
+    """Construye la credencial probando primero el env var inline (modo K8s
+    Secret) y después el path en disco (modo local dev). Devuelve `None` si
+    ninguno está disponible — el sender queda inactivo."""
+    inline = os.getenv("FIREBASE_SERVICE_ACCOUNT_JSON")
+    if inline:
+        try:
+            payload = json.loads(inline)
+            logging.info("[FCM] usando credencial desde FIREBASE_SERVICE_ACCOUNT_JSON (inline)")
+            return credentials.Certificate(payload)
+        except json.JSONDecodeError as e:
+            logging.error(f"[FCM] FIREBASE_SERVICE_ACCOUNT_JSON no es JSON válido: {e}")
+            return None
+        except Exception as e:
+            logging.error(f"[FCM] error parseando FIREBASE_SERVICE_ACCOUNT_JSON: {e}")
+            return None
+
+    path = os.getenv("FIREBASE_SERVICE_ACCOUNT_PATH")
+    if path:
+        if not os.path.exists(path):
+            logging.warning(
+                f"[FCM] FIREBASE_SERVICE_ACCOUNT_PATH apunta a un archivo que no "
+                f"existe ({path!r}); push inactivas"
+            )
+            return None
+        try:
+            logging.info(f"[FCM] usando credencial desde {path}")
+            return credentials.Certificate(path)
+        except Exception as e:
+            logging.error(f"[FCM] error leyendo credencial desde {path}: {e}")
+            return None
+
+    logging.warning(
+        "[FCM] ni FIREBASE_SERVICE_ACCOUNT_JSON ni FIREBASE_SERVICE_ACCOUNT_PATH "
+        "están configuradas; push inactivas"
+    )
+    return None
+
+
+def send_to_tokens(
+    tokens: Iterable[str],
+    title: str,
+    body: str,
+    data: Optional[dict] = None,
+) -> int:
+    """Envía una notificación FCM a cada token. Devuelve el número de envíos
+    exitosos. Si Firebase no está configurado, devuelve 0 sin levantar."""
+    if not _maybe_initialize():
+        return 0
+
+    payload_data = {str(k): str(v) for k, v in (data or {}).items()}
+    sent = 0
+    for token in tokens:
+        token = (token or "").strip()
+        if not token:
+            continue
+        try:
+            message = messaging.Message(
+                notification=messaging.Notification(title=title, body=body),
+                data=payload_data,
+                token=token,
+            )
+            response = messaging.send(message)
+            logging.info(f"[FCM] enviado {response} → {token[:12]}…")
+            sent += 1
+        except Exception as e:
+            # Tokens caducados / desregistrados / 404 — no es fatal.
+            logging.warning(f"[FCM] fallo enviando a {token[:12]}…: {e}")
+    return sent

--- a/services/service-core/main.py
+++ b/services/service-core/main.py
@@ -22,6 +22,7 @@ from routes.reservation_router import router as reservation_router
 from routes.reservation_state_machine_router import router as reservation_flow_router
 from routes.test_router import router as test_router
 from routes.hotel_admin_router import router as hotel_admin_router
+from routes.device_token_router import router as device_token_router
 from infrastructure.messaging.kafka.producer import publish_prueba
 from infrastructure.messaging.kafka.reply_consumer import wait_for_reply
 
@@ -129,6 +130,7 @@ app.include_router(reservation_router)
 app.include_router(reservation_flow_router)
 app.include_router(test_router)
 app.include_router(hotel_admin_router)
+app.include_router(device_token_router)
 
 
 @app.get("/config/kafka")

--- a/services/service-core/migrations/create_device_tokens.sql
+++ b/services/service-core/migrations/create_device_tokens.sql
@@ -1,0 +1,19 @@
+-- Tokens de push por dispositivo. Una fila por (usuario, token); un mismo
+-- token sólo puede pertenecer a un user_id activo a la vez (es lo que
+-- emite FCM/APNs por instalación + cuenta).
+
+DROP TABLE IF EXISTS device_tokens;
+
+CREATE TABLE device_tokens (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    token TEXT NOT NULL,
+    platform VARCHAR(16) NOT NULL CHECK (platform IN ('android', 'ios', 'web')),
+    app_version VARCHAR(32),
+    last_seen_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    UNIQUE (user_id, token)
+);
+
+CREATE INDEX device_tokens_user_id_idx ON device_tokens (user_id);
+CREATE INDEX device_tokens_token_idx ON device_tokens (token);

--- a/services/service-core/requirements.txt
+++ b/services/service-core/requirements.txt
@@ -1,5 +1,6 @@
 aiokafka==0.8.0
 asyncpg==0.30.0
+firebase-admin==6.5.0
 kafka-python-ng==2.2.3
 python-dotenv==1.0.1
 bcrypt==4.1.3

--- a/services/service-core/routes/device_token_router.py
+++ b/services/service-core/routes/device_token_router.py
@@ -1,0 +1,101 @@
+"""Endpoints para que el cliente registre/borre el token de push de su
+dispositivo. Todos JWT-only — el `user_id` se deriva del Bearer; el cliente
+nunca lo manda en el body.
+
+Contrato (alineado con el cliente Android `DeviceTokenApi`):
+
+    POST   /users/me/device-tokens
+        body: { "token": "...", "platform": "android"|"ios"|"web", "app_version": "0.1.1" }
+        201 Created — devuelve el `id` interno y `last_seen_at`.
+
+    DELETE /users/me/device-tokens
+        body: { "token": "..." }
+        204 No Content — borra solo este token (logout local de este device).
+"""
+from typing import Optional
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from infrastructure.database import get_session
+from user_service.repository.device_token_repository import (
+    DeviceTokenRepository,
+    VALID_PLATFORMS,
+)
+from user_service.utils.security import get_current_user
+
+
+router = APIRouter(prefix="/users/me/device-tokens", tags=["Device Tokens"])
+
+
+class RegisterDeviceTokenRequest(BaseModel):
+    token: str
+    platform: str
+    app_version: Optional[str] = None
+
+
+class DeleteDeviceTokenRequest(BaseModel):
+    token: str
+
+
+class DeviceTokenResponse(BaseModel):
+    id: UUID
+    user_id: UUID
+    platform: str
+    app_version: Optional[str]
+    last_seen_at: str
+    created_at: str
+
+
+@router.post("", response_model=DeviceTokenResponse, status_code=status.HTTP_201_CREATED)
+async def register_device_token(
+    body: RegisterDeviceTokenRequest,
+    current_user: dict = Depends(get_current_user),
+    session: AsyncSession = Depends(get_session),
+):
+    """Upsert del token. Idempotente: re-registrar el mismo token solo
+    refresca `last_seen_at`. El cliente debe llamar este endpoint cada vez
+    que FCM/APNs emita un token nuevo (`onNewToken`)."""
+    if body.platform not in VALID_PLATFORMS:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"platform must be one of {sorted(VALID_PLATFORMS)}",
+        )
+    if not body.token or not body.token.strip():
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="token must be non-empty",
+        )
+
+    user_id = UUID(current_user["user_id"])
+    repo = DeviceTokenRepository(session)
+    record = await repo.upsert(
+        user_id=user_id,
+        token=body.token.strip(),
+        platform=body.platform,
+        app_version=body.app_version,
+    )
+    return DeviceTokenResponse(
+        id=record.id,
+        user_id=record.user_id,
+        platform=record.platform,
+        app_version=record.app_version,
+        last_seen_at=record.last_seen_at.isoformat(),
+        created_at=record.created_at.isoformat(),
+    )
+
+
+@router.delete("", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_device_token(
+    body: DeleteDeviceTokenRequest,
+    current_user: dict = Depends(get_current_user),
+    session: AsyncSession = Depends(get_session),
+):
+    """Borra el token de este device para que el backend pare de mandar
+    pushes acá. Tolerante a que el token no exista (idempotente)."""
+    user_id = UUID(current_user["user_id"])
+    repo = DeviceTokenRepository(session)
+    await repo.delete(user_id=user_id, token=body.token.strip())
+    return None

--- a/services/service-core/routes/reservation_state_machine_router.py
+++ b/services/service-core/routes/reservation_state_machine_router.py
@@ -155,6 +155,17 @@ async def cancel_reservation(
         cancel_result = result.get('result')
         if cancel_result.get('success') and cancel_result.get('proceed'):
             await flow.send_email(email, cancel_result.get('message'))
+            # Push paralelo al email para mejor entregabilidad. Tolerante a
+            # fallos: si Firebase no está configurado, queda no-op.
+            await flow.send_push(
+                user_id=user_id,
+                title="Reserva cancelada",
+                body=cancel_result.get('message') or "Tu reserva fue cancelada.",
+                data={
+                    "category": "booking_cancellation",
+                    "confirmation_code": request.confirmation_code,
+                },
+            )
         return result
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))

--- a/services/service-core/state_machine/simple_reservation_flow.py
+++ b/services/service-core/state_machine/simple_reservation_flow.py
@@ -230,6 +230,55 @@ class SimpleReservationFlow:
                 logging.warning("[Mailer] MAILER o TOKEN_SOPORT_SERVICES no configurados, email no enviado")
         except Exception as e:
             logging.error(f"[Mailer] Error enviando email: {e}")
+
+    async def send_push(self, user_id, title: str, body: str, data: dict = None):
+        """
+        Envía una notificación push FCM al usuario indicado. Busca todos los
+        device_tokens registrados para `user_id`, llama a Firebase Admin SDK
+        en un thread auxiliar (el SDK es sync), y reporta cuántos envíos
+        tuvieron éxito.
+
+        Tolerante a fallos: si Firebase no está configurado (sin
+        FIREBASE_SERVICE_ACCOUNT_PATH), si el usuario no tiene tokens, o si
+        Firebase rechaza algunos tokens, NO levanta. El push es nice-to-have
+        — no debe abortar la confirmación de una reserva ya creada.
+        """
+        if user_id is None:
+            return  # reserva anónima → no hay user al que pushear
+        try:
+            import asyncio
+            from sqlmodel import select
+            from infrastructure.database import async_session_maker
+            from infrastructure.notifications.fcm_sender import send_to_tokens
+            from domain.models.device_token import DeviceToken
+
+            user_uuid = user_id if not isinstance(user_id, str) else UUID(user_id)
+
+            async with async_session_maker() as session:
+                stmt = select(DeviceToken).where(DeviceToken.user_id == user_uuid)
+                result = await session.execute(stmt)
+                tokens = [r.token for r in result.scalars().all() if r.token]
+
+            if not tokens:
+                logging.info(f"[FCM] user {user_uuid} sin device_tokens, skip push")
+                return
+
+            # firebase_admin.messaging.send es síncrono — lo corremos en el
+            # default executor para no bloquear el event loop.
+            loop = asyncio.get_event_loop()
+            sent = await loop.run_in_executor(
+                None,
+                send_to_tokens,
+                tokens,
+                title,
+                body,
+                data or {},
+            )
+            logging.info(
+                f"[FCM] {sent}/{len(tokens)} push entregados para user {user_uuid}"
+            )
+        except Exception as e:
+            logging.error(f"[FCM] error en send_push: {e}")
     
     # ========== EJECUCIÓN DEL FLUJO COMPLETO ==========
 
@@ -253,10 +302,31 @@ class SimpleReservationFlow:
         self.current_step = "create"
         self.history.append("create")
         step2 = await self.step_create()
-        
+
         if not step2["success"]:
             return {"completed": False, "step": "create", "result": step2}
-        
+
+        # Push notification: notificamos al viajero que su reserva quedó
+        # confirmada. Sólo aplica cuando hay user_id (reservas autenticadas);
+        # para reservas anónimas se ignora. Tolerante a fallos — si Firebase
+        # no está configurado o el envío falla, sólo queda en el log.
+        try:
+            hotel_name = (step2.get("hotel") or {}).get("name") or "tu hotel"
+            confirmation_code = step2.get("confirmation_code") or ""
+            reservation_id = step2.get("reservation_id") or ""
+            await self.send_push(
+                user_id=self.context.get("user_id"),
+                title="Reserva confirmada",
+                body=f"Tu reserva en {hotel_name} está lista. Código: {confirmation_code}",
+                data={
+                    "category": "booking_confirmation",
+                    "reservation_id": reservation_id,
+                    "confirmation_code": confirmation_code,
+                },
+            )
+        except Exception as e:
+            logging.error(f"[FCM] post-create send_push falló: {e}")
+
         return {
             "completed": True,
             "step": "create",

--- a/services/service-core/tests/unit/test_device_token_router.py
+++ b/services/service-core/tests/unit/test_device_token_router.py
@@ -1,0 +1,140 @@
+"""Tests del router `/users/me/device-tokens`. Mockean el repositorio para
+no necesitar BD real — el contrato testeado es la traducción HTTP/JSON +
+validaciones del payload + propagación del `user_id` desde el JWT.
+"""
+import uuid
+import datetime
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from routes.device_token_router import router as device_token_router
+from user_service.utils.security import get_current_user
+
+
+VALID_USER_ID = "a2000000-0000-0000-0000-000000000001"
+
+
+@pytest.fixture
+def client():
+    app = FastAPI()
+    app.include_router(device_token_router)
+    app.dependency_overrides[get_current_user] = lambda: {"user_id": VALID_USER_ID}
+    # `get_session` se reemplaza con un None: las rutas pasan el session al
+    # repo, pero el repo está mockeado a nivel de método.
+    from infrastructure.database import get_session
+    app.dependency_overrides[get_session] = lambda: None
+    return TestClient(app)
+
+
+def _fake_record(token: str = "fcm-abc"):
+    """DeviceToken-shaped object para que el response_model pueda construirse."""
+    now = datetime.datetime(2026, 5, 4, 12, 0, 0, tzinfo=datetime.timezone.utc)
+
+    class _Record:
+        pass
+
+    record = _Record()
+    record.id = uuid.UUID("d1000000-0000-0000-0000-000000000001")
+    record.user_id = uuid.UUID(VALID_USER_ID)
+    record.token = token
+    record.platform = "android"
+    record.app_version = "0.1.1"
+    record.last_seen_at = now
+    record.created_at = now
+    return record
+
+
+class TestRegisterDeviceToken:
+    def test_upserts_token_and_returns_201(self, client):
+        with patch(
+            "routes.device_token_router.DeviceTokenRepository.upsert",
+            new=AsyncMock(return_value=_fake_record()),
+        ):
+            response = client.post(
+                "/users/me/device-tokens",
+                json={
+                    "token": "fcm-abc",
+                    "platform": "android",
+                    "app_version": "0.1.1",
+                },
+            )
+
+        assert response.status_code == 201
+        body = response.json()
+        assert body["user_id"] == VALID_USER_ID
+        assert body["platform"] == "android"
+        assert body["app_version"] == "0.1.1"
+        assert body["last_seen_at"].startswith("2026-05-04T12:00:00")
+
+    def test_rejects_unknown_platform(self, client):
+        response = client.post(
+            "/users/me/device-tokens",
+            json={"token": "fcm-abc", "platform": "windows-phone"},
+        )
+        assert response.status_code == 400
+        assert "platform" in response.json()["detail"]
+
+    def test_rejects_blank_token(self, client):
+        response = client.post(
+            "/users/me/device-tokens",
+            json={"token": "   ", "platform": "android"},
+        )
+        assert response.status_code == 400
+
+    def test_app_version_is_optional(self, client):
+        with patch(
+            "routes.device_token_router.DeviceTokenRepository.upsert",
+            new=AsyncMock(return_value=_fake_record()),
+        ) as upsert_mock:
+            response = client.post(
+                "/users/me/device-tokens",
+                json={"token": "fcm-abc", "platform": "android"},
+            )
+        assert response.status_code == 201
+        # El repo recibe app_version=None cuando el cliente no lo envía.
+        kwargs = upsert_mock.call_args.kwargs
+        assert kwargs["app_version"] is None
+
+    def test_trims_token_before_persisting(self, client):
+        with patch(
+            "routes.device_token_router.DeviceTokenRepository.upsert",
+            new=AsyncMock(return_value=_fake_record()),
+        ) as upsert_mock:
+            response = client.post(
+                "/users/me/device-tokens",
+                json={"token": "  fcm-abc  ", "platform": "android"},
+            )
+        assert response.status_code == 201
+        assert upsert_mock.call_args.kwargs["token"] == "fcm-abc"
+
+
+class TestDeleteDeviceToken:
+    def test_deletes_existing_token_204(self, client):
+        with patch(
+            "routes.device_token_router.DeviceTokenRepository.delete",
+            new=AsyncMock(return_value=True),
+        ):
+            response = client.request(
+                "DELETE",
+                "/users/me/device-tokens",
+                json={"token": "fcm-abc"},
+            )
+        assert response.status_code == 204
+        assert response.text == ""
+
+    def test_idempotent_when_token_unknown(self, client):
+        # Repo devuelve False (no había nada que borrar) y aun así el
+        # endpoint responde 204 — semantica idempotente.
+        with patch(
+            "routes.device_token_router.DeviceTokenRepository.delete",
+            new=AsyncMock(return_value=False),
+        ):
+            response = client.request(
+                "DELETE",
+                "/users/me/device-tokens",
+                json={"token": "fcm-unknown"},
+            )
+        assert response.status_code == 204

--- a/services/service-core/user_service/repository/device_token_repository.py
+++ b/services/service-core/user_service/repository/device_token_repository.py
@@ -1,0 +1,100 @@
+"""Repositorio para `device_tokens`. Operaciones esperadas por el router:
+
+- `upsert(user_id, token, platform, app_version)` — idempotente. Si el par
+  (user_id, token) existe, actualiza `last_seen_at` (y `app_version` si
+  cambió). Si no existe, crea la fila.
+- `delete(user_id, token)` — borra el registro al hacer logout en ese
+  device, para que el backend no le siga mandando pushes.
+- `list_for_user(user_id)` — lo usa el adaptador FCM en service-external
+  (vía endpoint interno, fuera del scope de esta entrega) para resolver
+  destinos a partir de un user_id.
+"""
+import datetime
+import uuid
+from typing import List, Optional
+
+from sqlmodel import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from domain.models.device_token import DeviceToken
+
+
+VALID_PLATFORMS = {"android", "ios", "web"}
+
+
+class DeviceTokenRepository:
+    def __init__(self, session: AsyncSession):
+        self.session = session
+
+    async def get(self, user_id: uuid.UUID, token: str) -> Optional[DeviceToken]:
+        stmt = select(DeviceToken).where(
+            DeviceToken.user_id == user_id,
+            DeviceToken.token == token,
+        )
+        result = await self.session.execute(stmt)
+        return result.scalar_one_or_none()
+
+    async def list_for_user(self, user_id: uuid.UUID) -> List[DeviceToken]:
+        stmt = (
+            select(DeviceToken)
+            .where(DeviceToken.user_id == user_id)
+            .order_by(DeviceToken.last_seen_at.desc())
+        )
+        result = await self.session.execute(stmt)
+        return list(result.scalars().all())
+
+    async def upsert(
+        self,
+        user_id: uuid.UUID,
+        token: str,
+        platform: str,
+        app_version: Optional[str] = None,
+    ) -> DeviceToken:
+        if platform not in VALID_PLATFORMS:
+            raise ValueError(f"platform must be one of {VALID_PLATFORMS}, got {platform!r}")
+        if not token or not token.strip():
+            raise ValueError("token must be non-empty")
+
+        existing = await self.get(user_id, token)
+        # Naive UTC — `device_tokens.last_seen_at` es `TIMESTAMP WITHOUT TIME
+        # ZONE`. Si pasamos tz-aware, asyncpg lanza "can't subtract offset-
+        # naive and offset-aware datetimes" al codificar el parámetro.
+        now = datetime.datetime.utcnow()
+        if existing is not None:
+            existing.last_seen_at = now
+            if app_version is not None:
+                existing.app_version = app_version
+            existing.platform = platform
+            await self.session.commit()
+            await self.session.refresh(existing)
+            return existing
+
+        record = DeviceToken(
+            user_id=user_id,
+            token=token,
+            platform=platform,
+            app_version=app_version,
+            last_seen_at=now,
+            created_at=now,
+        )
+        self.session.add(record)
+        await self.session.commit()
+        await self.session.refresh(record)
+        return record
+
+    async def delete(self, user_id: uuid.UUID, token: str) -> bool:
+        record = await self.get(user_id, token)
+        if record is None:
+            return False
+        await self.session.delete(record)
+        await self.session.commit()
+        return True
+
+    async def delete_all_for_user(self, user_id: uuid.UUID) -> int:
+        """Borra todos los tokens de un usuario (logout global). Devuelve
+        el número de filas afectadas para que el caller pueda loggear."""
+        rows = await self.list_for_user(user_id)
+        for row in rows:
+            await self.session.delete(row)
+        await self.session.commit()
+        return len(rows)


### PR DESCRIPTION
## Summary

Implementa el lado backend de push notifications para TravelHub mobile (HU TRAVEL-173). Service-core acepta el registro/borrado de FCM tokens por usuario autenticado, persiste en una tabla nueva `device_tokens`, y envía pushes via Firebase Admin SDK cuando una reserva se confirma o se cancela. El envío es tolerante a fallos: si Firebase no está configurado (local dev sin credenciales), el reservation flow sigue funcionando sin romper nada.

## Changes

### Modelo + persistencia

- `domain/models/device_token.py` — SQLModel `device_tokens` con `(user_id, token)` UNIQUE.
- `migrations/create_device_tokens.sql` — migración Postgres con FK a `users(id)`.
- `infrastructure/database.py` — import del nuevo modelo en `init_db()` para que `metadata.create_all` lo materialice en local.
- `user_service/repository/device_token_repository.py` — repo con `upsert` idempotente, `delete`, `list_for_user`, `delete_all_for_user`.

### Endpoints (service-core)

- `POST /users/me/device-tokens` — registra/refresca un token (JWT-only).
- `DELETE /users/me/device-tokens` — borra un token específico de este device (logout local). Idempotente.
- Validación de payload: `platform` ∈ `{android, ios, web}`, `token` no-blank.

### FCM dispatch

- `infrastructure/notifications/fcm_sender.py` — wrapper de `firebase-admin` con init perezosa. Soporta dos modos:
  - `FIREBASE_SERVICE_ACCOUNT_JSON` (env var inline, recomendado en K8s)
  - `FIREBASE_SERVICE_ACCOUNT_PATH` (path en disco, para local dev)

  Si ninguna está, queda inactivo (no-op).
- `state_machine/simple_reservation_flow.send_push()` — busca `device_tokens` del user y dispara FCM en thread auxiliar.
- Hook en `run_create_flow` después de un create exitoso → notificación "Reserva confirmada".
- Hook en `routes/reservation_state_machine_router.py` (cancel) → notificación "Reserva cancelada".

### Dependencias + seguridad

- `requirements.txt` += `firebase-admin==6.5.0`.
- `.gitignore` += patterns para evitar commits accidentales de `*firebase-adminsdk*.json` y `google-services.json`.

### Tests

- `tests/unit/test_device_token_router.py` — 7 tests: upsert 201, validación de platform, validación de token blank, app_version opcional, trim de token, DELETE 204, DELETE idempotente.

## Deploy notes (K8s)

Para activar push en cualquier ambiente:

1. Generar service account JSON en Firebase Console → Project Settings → Service accounts → Generate new private key.

2. Crear Secret en el cluster:

   ```bash